### PR TITLE
fix: resolve Husky dependency issue in preview workflow

### DIFF
--- a/.github/workflows/generate-next-preview.yml
+++ b/.github/workflows/generate-next-preview.yml
@@ -65,7 +65,7 @@ jobs:
       
       - name: Install dependencies
         run: |
-          npm ci --only=production
+          npm ci
           # Security: Verify package integrity
           npm audit --audit-level=high
       
@@ -199,9 +199,6 @@ jobs:
         if: steps.discovery.outputs.found == 'true'
         run: |
           echo "Building integrated codebase..."
-          
-          # Install all dependencies including dev dependencies for build
-          npm ci
           
           # Run build process
           npm run build


### PR DESCRIPTION
Fixes the workflow failure by ensuring Husky is available during the prepare script.

**Changes:**
- Remove `--only=production` flag from npm ci to include dev dependencies
- Remove duplicate npm ci from build step since dependencies already installed

**Fixes:**
- `husky: not found` error during prepare script execution
- Workflow failure in TASK-TC-01 testing

This is required for the breaking change integration workflow to function properly.