### PR TITLE
Fix GitHub release creation with built-in token

### DIFF
--- a/.github/workflows/generate-next-preview.yml
+++ b/.github/workflows/generate-next-preview.yml
@@ -23,7 +23,7 @@ on:
 
 # Security: Minimal permissions following principle of least privilege
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: read
   packages: write
@@ -267,7 +267,7 @@ jobs:
         if: steps.discovery.outputs.found == 'true'
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.PREVIEW_VERSION }}
           release_name: "Preview Release ${{ env.PREVIEW_VERSION }}"

--- a/README.md
+++ b/README.md
@@ -139,3 +139,4 @@ For testing-related issues or questions:
 **Last Updated**: 2025-07-24
 **Test Phase**: Infrastructure Setup
 **Status**: Active Testing Repository
+trigger workflow clean


### PR DESCRIPTION
## Summary
Simple fix for release creation permissions using built-in GITHUB_TOKEN instead of complex GitHub App setup.

## Changes
- ✅ Change `contents: read` to `contents: write` in workflow permissions
- ✅ Replace `secrets.BOT_PAT` with `secrets.GITHUB_TOKEN` for release step
- ✅ Built-in token inherits workflow permissions automatically

## Why This Works
The built-in `GITHUB_TOKEN` gets whatever permissions are specified in the workflow's `permissions` section. With `contents: write`, it should have release creation access.

## Benefits vs GitHub App
- ✅ No additional secrets or app setup required
- ✅ Uses GitHub's built-in security model
- ✅ Simpler and more maintainable
- ✅ Should resolve 'Resource not accessible by personal access token' error

Ready to test complete end-to-end workflow with release creation\!