### PR TITLE
Skip GitHub release creation when conflicts detected

### DIFF
--- a/.github/workflows/generate-next-preview.yml
+++ b/.github/workflows/generate-next-preview.yml
@@ -264,7 +264,7 @@ jobs:
           echo "Created release candidate branch: $RC_BRANCH"
       
       - name: Create GitHub release
-        if: steps.discovery.outputs.found == 'true'
+        if: steps.discovery.outputs.found == 'true' && steps.integration.outputs.conflicts == 'false'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -415,8 +415,8 @@ jobs:
               body += '**Status**: ✅ No breaking changes found\n';
               body += '**Action**: None required - develop ready for patch/minor release\n';
             } else if (conflicts) {
-              body += `**Status**: ⚠️ Partial preview generated\n`;
-              body += `**Version**: \`${version}\`\n`;
+              body += `**Status**: ⚠️ Conflicts detected - no release created\n`;
+              body += `**Action**: Resolve conflicts in breaking change branches\n`;
               body += `**Conflicts**: See issues for resolution steps\n`;
             } else {
               body += `**Status**: ✅ Complete preview generated\n`;


### PR DESCRIPTION
## Summary
Improve workflow behavior by only creating GitHub releases when integration is completely successful, avoiding confusing partial releases.

## Changes
- ✅ Updated release creation condition: `discovery.found == 'true' && integration.conflicts == 'false'`
- ✅ Updated commit comment status to reflect 'no release created' when conflicts exist
- ✅ Issues still created for conflict tracking and resolution guidance

## Before
- ❌ Partial releases created with 'Integration status: ⚠️ Partial (conflicts detected)'
- ❌ Confusing for users seeing incomplete releases in GitHub releases list

## After  
- ✅ Only complete integrations create GitHub releases
- ✅ Conflict issues provide clear resolution guidance
- ✅ Cleaner release history showing only working versions
- ✅ Status shows 'Conflicts detected - no release created'

## Impact
- **GitHub Releases**: Only successful complete integrations 
- **Issues**: Conflicts still tracked with resolution steps
- **Users**: Cleaner experience with working releases only

Ready to test with a conflicted scenario\!