### PR TITLE
feat\!: remove deprecated APIs and bump version to 0.2.0

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,13 @@
+# Breaking Changes
+
+## Migration Guide
+
+### Removed APIs
+- `Transaction.submit()` -> Use `Transaction.submitAndWait()`
+
+### Updated Interfaces
+- `ErrorResponse` now includes `context` and `timestamp` fields
+- `Transaction` now requires `metadata` field
+
+### Configuration Changes
+- Default network timeout changed from 10s to 30s

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@test-org/polymesh-sdk-integration-test",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Test repository for Ephemeral Next Major Release Integration process",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api/PolymeshAPI.ts
+++ b/src/api/PolymeshAPI.ts
@@ -39,7 +39,7 @@ export class PolymeshAPI {
    * Gets paginated transactions
    * Pagination interface may change in breaking change tests
    */
-  async getTransactions(options: PaginationOptions): Promise<APIResponse<any[]>> {
+  async getTransactions(options: PaginationOptions): Promise<APIResponse<unknown[]>> {
     try {
       const allTransactions = this.transactionManager.getAllTransactions();
       const startIndex = (options.page - 1) * options.limit;
@@ -49,13 +49,13 @@ export class PolymeshAPI {
 
       if (options.sortBy) {
         sortedTransactions.sort((a, b) => {
-          const aValue = (a as any)[options.sortBy!];
-          const bValue = (b as any)[options.sortBy!];
+          const aValue = (a as unknown as Record<string, unknown>)[options.sortBy || 'id'];
+          const bValue = (b as unknown as Record<string, unknown>)[options.sortBy || 'id'];
 
           if (options.sortOrder === 'desc') {
-            return bValue > aValue ? 1 : -1;
+            return String(bValue) > String(aValue) ? 1 : -1;
           }
-          return aValue > bValue ? 1 : -1;
+          return String(aValue) > String(bValue) ? 1 : -1;
         });
       }
 
@@ -64,7 +64,7 @@ export class PolymeshAPI {
       return this.createResponse(paginatedTransactions);
     } catch (error) {
       const handledError = this.errorHandler.handle(error);
-      return this.createResponse([] as any[], handledError.message);
+      return this.createResponse([] as unknown[], handledError.message);
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 // Updated default configuration - BREAKING CHANGE
 export const DEFAULT_CONFIG = {
-  networkTimeout: 30000,  // Changed from 10000 - BREAKING CHANGE
+  networkTimeout: 30000, // Changed from 10000 - BREAKING CHANGE
   retryAttempts: 3,
-  enableLogging: true
+  enableLogging: true,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,6 @@
+// Updated default configuration - BREAKING CHANGE
+export const DEFAULT_CONFIG = {
+  networkTimeout: 30000,  // Changed from 10000 - BREAKING CHANGE
+  retryAttempts: 3,
+  enableLogging: true
+};

--- a/src/deprecated-apis.ts
+++ b/src/deprecated-apis.ts
@@ -1,0 +1,12 @@
+// Deprecated APIs removed - BREAKING CHANGE
+// The submit() method has been removed
+// Use submitAndWait() instead
+
+export class Transaction {
+  // submit() method removed - BREAKING CHANGE
+  
+  async submitAndWait(): Promise<void> {
+    // New implementation
+    console.log('Transaction submitted and waiting for confirmation');
+  }
+}

--- a/src/deprecated-apis.ts
+++ b/src/deprecated-apis.ts
@@ -4,9 +4,10 @@
 
 export class Transaction {
   // submit() method removed - BREAKING CHANGE
-  
+
   async submitAndWait(): Promise<void> {
     // New implementation
-    console.log('Transaction submitted and waiting for confirmation');
+    // Transaction submitted and waiting for confirmation
+    return Promise.resolve();
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,6 @@
 export interface ErrorResponse {
   code: string;
   message: string;
-  context: Record<string, any>; // New field - BREAKING CHANGE
+  context: Record<string, unknown>; // New field - BREAKING CHANGE
   timestamp: Date; // New field - BREAKING CHANGE
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,7 @@
+// Updated error structure - BREAKING CHANGE
+export interface ErrorResponse {
+  code: string;
+  message: string;
+  context: Record<string, any>; // New field - BREAKING CHANGE
+  timestamp: Date; // New field - BREAKING CHANGE
+}

--- a/src/transaction/TransactionManager.ts
+++ b/src/transaction/TransactionManager.ts
@@ -49,6 +49,7 @@ export class TransactionManager {
         amount: validatedParams.amount,
         recipient: validatedParams.recipient,
         status: TransactionStatus.PENDING,
+        metadata: { source: 'api', version: '1.0' }, // Required by breaking change
         createdAt: new Date(),
         updatedAt: new Date(),
       };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export interface Transaction {
   amount: number;
   recipient: string;
   status: TransactionStatus;
+  metadata: Record<string, any>; // New required field - BREAKING CHANGE
   createdAt: Date;
   updatedAt: Date;
   // New fields may be added in breaking change tests

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,7 +23,7 @@ export interface Transaction {
   amount: number;
   recipient: string;
   status: TransactionStatus;
-  metadata: Record<string, any>; // New required field - BREAKING CHANGE
+  metadata: Record<string, unknown>; // New required field - BREAKING CHANGE
   createdAt: Date;
   updatedAt: Date;
   // New fields may be added in breaking change tests

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,7 +72,7 @@ export interface Asset {
 }
 
 // API types - may be restructured in breaking change tests
-export interface APIResponse<T = any> {
+export interface APIResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: string;


### PR DESCRIPTION
## Summary
- Bumped version from 0.1.0 to 0.2.0
- Preparing for final integration tests
- Clean state for breaking change validation

## Breaking Changes
This is part of the bc-1-remove-deprecated-apis branch containing breaking changes that will be tested through the Ephemeral Next Major Release Integration process.

## Test Plan
- Version bump applied correctly
- Ready for integration testing workflow