### PR TITLE
fix: improve shell script efficiency with block redirect

### DIFF
--- a/.github/workflows/generate-next-preview.yml
+++ b/.github/workflows/generate-next-preview.yml
@@ -222,10 +222,12 @@ jobs:
           done
 
           # Set outputs for downstream steps - all branches successful since pre-validated
-          echo "SUCCESSFUL_BRANCHES=$BC_BRANCHES" >> "$GITHUB_ENV"
-          echo "BREAKING_CHANGE_METADATA<<EOF" >> "$GITHUB_ENV"
-          echo -e "$BREAKING_CHANGE_METADATA" >> "$GITHUB_ENV"
-          echo "EOF" >> "$GITHUB_ENV"
+          {
+            echo "SUCCESSFUL_BRANCHES=$BC_BRANCHES"
+            echo "BREAKING_CHANGE_METADATA<<EOF"
+            echo -e "$BREAKING_CHANGE_METADATA"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
           echo "conflicts=false" >> "$GITHUB_OUTPUT"
           echo "All breaking changes applied successfully"
 


### PR DESCRIPTION
## Problem

Shellcheck was reporting a style warning (SC2129) about inefficient use of individual redirects:

```
Error: .github/workflows/generate-next-preview.yml:170:9: shellcheck reported issue in this script: SC2129:style:55:1: Consider using { cmd1; cmd2; } >> file instead of individual redirects [shellcheck]
```

## Solution

Replace multiple individual redirects with a single block redirect for better efficiency:

**Before (4 file operations):**
```bash
echo "SUCCESSFUL_BRANCHES=$BC_BRANCHES" >> "$GITHUB_ENV"
echo "BREAKING_CHANGE_METADATA<<EOF" >> "$GITHUB_ENV"
echo -e "$BREAKING_CHANGE_METADATA" >> "$GITHUB_ENV"
echo "EOF" >> "$GITHUB_ENV"
```

**After (1 file operation):**
```bash
{
  echo "SUCCESSFUL_BRANCHES=$BC_BRANCHES"
  echo "BREAKING_CHANGE_METADATA<<EOF"
  echo -e "$BREAKING_CHANGE_METADATA"
  echo "EOF"
} >> "$GITHUB_ENV"
```

## Benefits

- ✅ **Performance**: Reduces file operations from 4 to 1
- ✅ **Best Practices**: Follows shellcheck recommendations
- ✅ **Functionality**: Identical behavior, more efficient execution
- ✅ **Actionlint Clean**: Resolves the shellcheck warning

## Testing

- ✅ Actionlint passes with no warnings
- ✅ Functionality unchanged - same environment variables set
- ✅ Block redirect is equivalent to individual redirects